### PR TITLE
Catched exception in album_load. Unsupported image formats would stop the routine

### DIFF
--- a/coverart_browser.py
+++ b/coverart_browser.py
@@ -442,13 +442,16 @@ class CoverArtBrowserPlugin(GObject.Object, Peas.Activatable):
 	    #print "CoverArtBrowser DEBUG - album_load, art_location = "
 	    art_location = self.cover_db.lookup(key)
             if art_location is not None and os.path.exists (art_location):
-                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(art_location, CoverSize, CoverSize)
-		#print "CoverArtBrowser DEBUG - album_load OK"
-                self.cover_count += 1
-                Gdk.threads_enter()
-                self.covers_model.set(tree_iter, 1, pixbuf)
-		self.set_status()
-                Gdk.threads_leave()
+            	try:
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(art_location, CoverSize, CoverSize)
+		    #print "CoverArtBrowser DEBUG - album_load OK"
+                    self.cover_count += 1
+                    Gdk.threads_enter()
+                    self.covers_model.set(tree_iter, 1, pixbuf)
+		    self.set_status()
+                    Gdk.threads_leave()
+	    	except:
+	    	    pass
 	    if self.album_queue.empty():
 		Gdk.threads_enter()
 		print "CoverArtBrowser DEBUG - album_load() FINISHED"


### PR DESCRIPTION
The routine would stop at some point when it found a unsupported image format on my music directory. I just added a try;except to catch the exception and ignore it.

On a side note:
I really like how the plugin looks and I can imagine all the functionality that can be build over it. Neverthless, I think after porting (or at the same time, why not), the code should get a major refactoring, for various reasons:
- The code, as it is, is pretty hard to maintain or extend. It's understandable, but it's harder to handle than it should. I, personally, would preffer to make it a little more object oriented.
- The indentation is a mess.
- The performance while loading the covers is pretty poor. In my case, it would take around 30 segs to populate the view, and it flickered constantly until the routine finished. A better approach would be to load only the covers of albums shown on the viewport, for example.

I get that probably your first intention is to port it; in any case, if you-- we(coz I'm interested on it too d:) intend to fix some stuff and add functionlity, a little effort refactoring it would probably save us some headaches on the future.

Anyway, great plugin foss, nice going :3
