### PR TITLE
Patch 2 - Additional genres and French translations

### DIFF
--- a/img/popups.xml
+++ b/img/popups.xml
@@ -44,13 +44,13 @@
         <alt genre="alternative">gothic</alt>
         <alt genre="alternative">alt. rock</alt>
         <alt genre="dance">trip hop</alt>
-        <alt genre="dance">House</alt>
+        <alt genre="dance">house</alt>
         <alt genre="holiday">christmas</alt>
         <alt genre="oldies">swing</alt>
         <alt genre="children">kids</alt>
         <alt genre="blues">r&amp;b</alt>
         <alt genre="electronic">industrial</alt>
-        <alt genre="folk">acoustique</alt>
+        <alt genre="folk">acoustic</alt>
         <alt genre="electronic">ambient</alt>
         <alt genre="gospel">christian</alt>
         


### PR DESCRIPTION
Here are some additional genres alternate mapping.

Looking @londumas' list of genres, I realized that not everybody have their genres set to English.  So I modified popups.xml to provide basic French translation.

Do you think it is the place to do it?
Also, does it support unicode?  For the "e" with an accent, I tried to input  & e a c u t e ; like you have done on R and B, but that did not work.

EDIT:  Please correct the world "accoustique" (should be "accoustic"  in the alternate English section and lower case the "H" on "House".
