### PR TITLE
enable passing a custom stock_id for actions

### DIFF
--- a/coverart_rb3compat.py
+++ b/coverart_rb3compat.py
@@ -460,14 +460,19 @@ class ActionGroup(object):
             if accel:
                 app.add_accelerator(accel, action_type+"."+action_name, None)
         else:
+            if 'stock_id' in args:
+                stock_id = args['stock_id']
+            else:
+                stock_id = Gtk.STOCK_CLEAR
+                
             if state == ActionGroup.TOGGLE:
                 action = Gtk.ToggleAction(label=label,
                     name=action_name,
-                   tooltip='', stock_id=Gtk.STOCK_CLEAR)
+                   tooltip='', stock_id=stock_id)
             else:
                 action = Gtk.Action(label=label,
                     name=action_name,
-                   tooltip='', stock_id=Gtk.STOCK_CLEAR)
+                   tooltip='', stock_id=stock_id)
                    
             if accel:
                 self.actiongroup.add_action_with_accel(action, accel)


### PR DESCRIPTION
I love your compatibility module and now use it for my lLyrics plugin. Thank you!

The only issue I had: I wanted to keep the toolbar icon for RB<2.99. But in order to show the correct icon, one must be able to pass a custom stock_id to the toggle action. Thats the only thing I added.
