### PR TITLE
rename variable to avoid use of key word

### DIFF
--- a/coverart_album.py
+++ b/coverart_album.py
@@ -1587,8 +1587,8 @@ class CoverManager(GObject.Object):
                             print("The URI doesn't point to an image or " + \
                                   "the image couldn't be opened.")
 
-                async = rb.Loader()
-                async.get_url(uri, cover_update, coverobject)
+                asyncLoader = rb.Loader()
+                asyncLoader.get_url(uri, cover_update, coverobject)
 
 
 class AlbumCoverManager(CoverManager):


### PR DESCRIPTION
By renaming this variable, the plugin works again on Ubuntu 19.04